### PR TITLE
fix: prevent completions/mcp subcommands from silently overwriting user-defined commands

### DIFF
--- a/src/xclif/__init__.py
+++ b/src/xclif/__init__.py
@@ -205,11 +205,12 @@ class Cli:
             if local_data:
                 self._config_data = _deep_merge(self._config_data, local_data)
 
-        # Add completions subcommand
+        # Add completions subcommand (skip if user already defined one)
         self.root_command._assert_no_arguments(adding="completions")
-        self.root_command.subcommands["completions"] = make_completions_command(
-            self.root_command
-        )
+        if "completions" not in self.root_command.subcommands:
+            self.root_command.subcommands["completions"] = make_completions_command(
+                self.root_command
+            )
 
         # Inject --version as an implicit option on root command only
         self.root_command.implicit_options["version"] = _DefinitionOption(
@@ -228,7 +229,8 @@ class Cli:
             else:
                 from xclif.mcp import make_mcp_command
                 self.root_command._assert_no_arguments(adding="mcp")
-                self.root_command.subcommands["mcp"] = make_mcp_command(self.root_command)
+                if "mcp" not in self.root_command.subcommands:
+                    self.root_command.subcommands["mcp"] = make_mcp_command(self.root_command)
 
     def _apply_show_no_description(self, cmd: Command) -> None:
         """Recursively apply Cli-level show_no_description default to the tree."""


### PR DESCRIPTION
## Description

Fixes #61

**Problem:** `Cli.__post_init__` unconditionally injected `completions` and `mcp` subcommands via `self.root_command.subcommands["completions"] = ...`, silently overwriting any user-defined subcommand with the same name.

**Fix:** Added a guard check (`if "completions" not in self.root_command.subcommands` / `if "mcp" not in self.root_command.subcommands`) before injecting, matching the existing pattern used for the `config` subcommand in `_finalize()` (line 258).

### Changes

- `src/xclif/__init__.py`: Added collision guards around completions and mcp subcommand injection in `Cli.__post_init__`

### Testing

All 359 existing tests pass (3 skipped, same as before).

```
======================== 359 passed, 3 skipped in 5.49s ========================
```