### PR TITLE
:bug: fix(annotations): register Path converter for xclif.Path params

### DIFF
--- a/src/xclif/__init__.py
+++ b/src/xclif/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "Cli",
     "Context",
     "Option",
+    "Path",
     "WithConfig",
     "__version__",
     "command",

--- a/src/xclif/annotations.py
+++ b/src/xclif/annotations.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 from typing import Annotated, Callable, Literal, get_args, get_origin
 
 __all__ = ["annotation2converter", "is_list_type", "unwrap_param_metadata", "unwrap_with_config"]
 
-type ScalarParameterTypes = str | int | float | bool
+type ScalarParameterTypes = str | int | float | bool | Path
 type ParameterTypes = ScalarParameterTypes | list[ScalarParameterTypes]
-_default_converters = {str: str, int: int, float: float, bool: bool}
+_default_converters = {str: str, int: int, float: float, bool: bool, Path: Path}
 
 
 def unwrap_with_config(annotation) -> tuple[type, "WithConfig | None"]:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,6 @@
 """Unit tests for xclif.annotations."""
 import pytest
+from pathlib import Path
 from typing import Literal
 from xclif.annotations import annotation2converter
 
@@ -30,3 +31,12 @@ def test_literal_single_value():
 def test_non_literal_unchanged():
     assert annotation2converter(str) is str
     assert annotation2converter(int) is int
+
+
+def test_path_converter():
+    conv = annotation2converter(Path)
+    assert conv("/tmp/x") == Path("/tmp/x")
+
+
+def test_list_path_converter():
+    assert annotation2converter(list[Path]) is Path


### PR DESCRIPTION
## Problem

`Path` is re-exported from the package (`xclif.Path` is literally `pathlib.Path`) and the docs imply type-based coercion works for it, but `Path` was **not** in `_default_converters` (which held only `str`, `int`, `float`, `bool`). So:

```python
from xclif import command
from pathlib import Path

@command()
def run(script: Path) -> None: ...  # TypeError: Unsupported type
```

failed at decorator time. `xclif.Path` being exported signals it is meant to be used as a parameter type, so this is a bug, not just a missing feature.

## Fix

Register `Path` in `_default_converters` (the `Path` constructor doubles as its converter — `Path(value)`) and add it to `ScalarParameterTypes`. Also add `Path` to the package `__all__` to make the export contract explicit. `Path` now works as a positional arg type and inside `list[Path]`.

## Tests

- `annotation2converter(Path)` → coerces `"/tmp/x"` to `Path("/tmp/x")`
- `annotation2converter(list[Path])` → `Path`

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)