### PR TITLE
:bug: Make completions/mcp injection conditional (#61)

### DIFF
--- a/src/xclif/__init__.py
+++ b/src/xclif/__init__.py
@@ -172,10 +172,18 @@ class Cli:
         Whether to auto-inject the ``config`` subcommand when any parameter
         uses :class:`~xclif.config.WithConfig`.  *True* (the default) keeps
         the current behaviour; set to *False* to suppress it.
+    completions_command:
+        Whether to auto-inject the ``completions`` subcommand.  *True* (the
+        default) keeps the current behaviour; set to *False* to suppress it.
+        Injection is also skipped when the root command already defines a
+        ``completions`` subcommand or declares positional arguments (since a
+        command with positional args cannot have subcommands).
     mcp_command:
         Whether to auto-inject the ``mcp`` subcommand when the optional
         ``mcp`` package is installed.  *True* (the default) keeps the
-        current behaviour; set to *False* to suppress it.
+        current behaviour; set to *False* to suppress it.  Injection is also
+        skipped when the root command already defines an ``mcp`` subcommand
+        or declares positional arguments.
     show_no_description:
         Default value for ``show_no_description`` on all commands in the
         tree.  When ``False``, suppress the "No description" placeholder in
@@ -191,6 +199,7 @@ class Cli:
     config_name: str | None = None
     local_config: str | None = None
     config_command: bool = True
+    completions_command: bool = True
     mcp_command: bool = True
     show_no_description: bool | None = None
     _config_data: dict = field(default_factory=dict, init=False, repr=False)
@@ -219,11 +228,17 @@ class Cli:
             if local_data:
                 self._config_data = _deep_merge(self._config_data, local_data)
 
-        # Add completions subcommand
-        self.root_command._assert_no_arguments(adding="completions")
-        self.root_command.subcommands["completions"] = make_completions_command(
-            self.root_command
-        )
+        # Add completions subcommand.  Skip when disabled, when the user
+        # already defined a 'completions' subcommand, or when the root command
+        # takes positional arguments (which forbid subcommands entirely).
+        if (
+            self.completions_command
+            and "completions" not in self.root_command.subcommands
+            and not self.root_command.arguments
+        ):
+            self.root_command.subcommands["completions"] = make_completions_command(
+                self.root_command
+            )
 
         # Inject --version as an implicit option on root command only
         self.root_command.implicit_options["version"] = _DefinitionOption(
@@ -233,15 +248,20 @@ class Cli:
         )
         self.root_command.version = self.version
 
-        # Add mcp subcommand (only if mcp optional dep is installed)
-        if self.mcp_command:
+        # Add mcp subcommand (only if mcp optional dep is installed).  Skip
+        # when the user already defined an 'mcp' subcommand or when the root
+        # command takes positional arguments.
+        if (
+            self.mcp_command
+            and "mcp" not in self.root_command.subcommands
+            and not self.root_command.arguments
+        ):
             try:
                 import mcp as _mcp_pkg  # noqa: F401
             except ImportError:
                 pass  # mcp optional dep not installed; subcommand silently absent
             else:
                 from xclif.mcp import make_mcp_command
-                self.root_command._assert_no_arguments(adding="mcp")
                 self.root_command.subcommands["mcp"] = make_mcp_command(self.root_command)
 
     def _apply_show_no_description(self, cmd: Command) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,32 @@ def test_cli_completions_is_single_command_with_shell_arg():
     assert comp.arguments[0].choices == ["bash", "zsh", "fish"]
 
 
+def test_cli_does_not_overwrite_user_completions_command(capsys):
+    """A user-defined 'completions' subcommand is preserved (issue #61)."""
+    root = Command("myapp", lambda: 0)
+    user_completions = Command("completions", lambda: 42)
+    root.subcommands["completions"] = user_completions
+
+    cli = Cli(root_command=root)
+    assert cli.root_command.subcommands["completions"] is user_completions
+
+
+def test_cli_does_not_overwrite_user_mcp_command():
+    """A user-defined 'mcp' subcommand is preserved (issue #61)."""
+    root = Command("myapp", lambda: 0)
+    user_mcp = Command("mcp", lambda: 7)
+    root.subcommands["mcp"] = user_mcp
+
+    cli = Cli(root_command=root)
+    assert cli.root_command.subcommands["mcp"] is user_mcp
+
+
+def test_cli_completions_command_flag_suppresses_injection():
+    root = Command("myapp", lambda: 0)
+    cli = Cli(root_command=root, completions_command=False)
+    assert "completions" not in cli.root_command.subcommands
+
+
 def test_cli_add_command_single_level():
     root = Command("myapp", lambda: 0)
     cli = Cli(root_command=root)
@@ -96,12 +122,18 @@ def test_cli_add_command_direct_to_root_with_arguments_raises():
         cli.add_command(["sub"], Command("sub", lambda: 0))
 
 
-def test_cli_construction_with_root_having_arguments_raises():
+def test_cli_construction_with_positional_root_skips_injection():
+    """A root command with positional args is expressible; framework
+    subcommands are silently skipped rather than raising (issue #61)."""
+
     @command()
     def root(name: str) -> None: ...
 
-    with pytest.raises(ValueError, match="Cannot add subcommand"):
-        Cli(root_command=root)
+    cli = Cli(root_command=root)
+    assert "completions" not in cli.root_command.subcommands
+    assert "mcp" not in cli.root_command.subcommands
+    # --version implicit option is still injected
+    assert "version" in cli.root_command.implicit_options
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #61.

## Problem

`Cli.__post_init__` injected the framework `completions` and `mcp` subcommands unconditionally:

1. **Silent overwrite** — a user-defined `completions`/`mcp` subcommand was clobbered (unlike `config`, which checks for an existing name first).
2. **Positional root incompatible** — `_assert_no_arguments` *raised* when the root command declared positional args, with no way to suppress it. A single root command taking a positional was inexpressible via `Cli`; bypassing `Cli` lost the injected `--version` implicit option.

## Fix

- `completions`/`mcp` inject only when the name is free **and** the root has no positional args — matches the existing `config` skip-if-exists pattern, and skips (rather than raises) for a positional root.
- Added a `completions_command: bool = True` flag (parallel to `config_command` / `mcp_command`) for explicit suppression.
- `--version` implicit option is still injected on a positional root.

## Tests

- Rewrote `test_cli_construction_with_root_having_arguments_raises` → `..._positional_root_skips_injection` (the old test encoded the bug).
- Added: user-`completions` preserved, user-`mcp` preserved, `completions_command=False` suppression.

Full suite: 390 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)