### PR TITLE
[codex] allow explicit option aliases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,8 @@ Type annotations are resolved to converter callables through
 
 Auto-generated short aliases (e.g. `-n` for `--name`) are assigned during
 extraction, skipping any letters already claimed by implicit options (`-h`, `-v`).
+Explicit aliases may be provided with `Option(aliases=[...])`; these can be short
+or long forms and skip auto-generation.
 
 ### 3. Token Parsing (`_parse_token_stream`)
 
@@ -71,6 +73,7 @@ The scanner is a single left-to-right pass over the token list. It recognises:
 
 - **Long options**: `--name value`, `--name=value`
 - **Short options**: `-n value`, `-v` (aliases resolved via `_build_alias_map`)
+- **Long aliases**: `--alias value`, `--alias=value`
 - **Boolean flags**: `--verbose`, `-v` (no value consumed)
 - **`--` separator**: everything after it becomes a raw positional
 - **Subcommand names**: scanning stops immediately; the index is returned
@@ -124,7 +127,7 @@ The central node type. Every command — root, namespace, or leaf — is a
 ### `Argument` / `Option` (definition.py)
 
 Simple dataclasses. `Argument` has a `variadic` flag. `Option` has `aliases`
-(short forms), `cascading` (propagates to children), and `default`.
+(short or long forms), `cascading` (propagates to children), and `default`.
 
 ### Implicit vs User Options
 
@@ -169,7 +172,7 @@ keeping a single source of truth for the defaults.
 1. Add it to `IMPLICIT_OPTIONS` in `definition.py`
 2. Handle it in `parse_and_execute_impl` in `parser.py` (after the help/version block)
 3. If cascading, add context accumulation logic
-4. Reserve its short alias (e.g. `-q`) in the `IMPLICIT_OPTIONS` entry
+4. Reserve its aliases (e.g. `-q`) in the `IMPLICIT_OPTIONS` entry
 
 ### New CLI-level feature (e.g. `--no-color`)
 

--- a/docs/option-system-design.md
+++ b/docs/option-system-design.md
@@ -16,14 +16,15 @@ This document defines the option/argument parsing model for Xclif: what syntax i
 
 Long option names use `kebab-case` on the CLI; they map to `snake_case` in Python. `--dry-run` → `dry_run`.
 
-### Short aliases
+### Option aliases
 
 ```
 -v                   # single-char boolean flag
 -n value             # single-char value option
+--dryrun             # explicit long alias
 ```
 
-Short aliases are either auto-generated (first char of the long name, falling back on subsequent chars to avoid collisions) or explicitly declared via `Annotated` metadata. Short options do **not** support bundling (`-abc` ≠ `-a -b -c`) — this is intentional. Bundling is a source of subtle bugs and is rarely needed in modern CLIs.
+Short aliases are either auto-generated (first char of the long name, falling back on subsequent chars to avoid collisions) or explicitly declared via `Annotated` metadata. Explicit aliases may also be long forms such as `--dryrun`. Short options do **not** support bundling (`-abc` ≠ `-a -b -c`) — this is intentional. Bundling is a source of subtle bugs and is rarely needed in modern CLIs.
 
 ### Positional arguments
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -78,15 +78,31 @@ Usage::
    myapp publish --tag latest --tag stable
    # tag = ["latest", "stable"]
 
-Short aliases
--------------
+Option aliases
+--------------
 
 Xclif auto-generates a single-char short alias for each option using the first available
 character of the option name. ``--template`` → ``-t``, ``--release`` → ``-r``, etc.
 
 If the first character is taken by an implicit option (``-h``, ``-v``), Xclif tries subsequent
-characters. Use ``Option(name=...)`` inside ``Annotated`` to override the flag name explicitly —
-see :ref:`per-parameter metadata <per-param-metadata>` below.
+characters.
+
+To specify explicit aliases instead of relying on auto-generation, use
+``Option(aliases=[...])`` inside ``Annotated``:
+
+.. code-block:: python
+
+   from typing import Annotated
+   from xclif import Option, command
+
+   @command()
+   def build(
+       dry_run: Annotated[bool, Option(aliases=["-n", "--dryrun"])] = False,
+   ) -> int:
+       ...
+
+Explicit aliases bypass auto-generation entirely. Conflicts with implicit options or other
+option aliases are detected at definition time and raise ``ValueError``.
 
 Interspersed options
 --------------------
@@ -148,6 +164,8 @@ display names and flag names:
 - ``description`` — text shown next to the flag in help output
 - ``name`` — overrides the CLI flag name (e.g. ``dry-run`` → ``--dry-run``). The Python
   kwarg name passed to the function is unchanged.
+- ``aliases`` — explicit short or long aliases (e.g. ``["-n", "--dryrun"]``). When
+  provided, auto-generation is skipped. Conflicts are caught at definition time.
 
 Both can be combined with ``WithConfig``. Note that ``WithConfig[str]`` is sugar for
 ``Annotated[str, WithConfig()]`` — when combining with ``Arg`` or ``Option`` you must

--- a/src/xclif/__init__.py
+++ b/src/xclif/__init__.py
@@ -131,6 +131,7 @@ class Option:
 
     description: str | None = None
     name: str | None = None  # CLI flag name override (e.g. "dry-run" → --dry-run)
+    aliases: list[str] | None = None  # explicit short/long aliases (e.g. ["-n", "--dry"])
 
 
 def _deep_merge(base: dict, override: dict) -> dict:

--- a/src/xclif/command.py
+++ b/src/xclif/command.py
@@ -466,11 +466,52 @@ def _get_choices(converter) -> list[str] | None:
 def _auto_alias(name: str, taken: set[str]) -> list[str]:
     """Try to auto-generate a single-char short alias for an option name."""
     for char in name:
+        if char == "-":
+            continue
         alias = f"-{char}"
         if alias not in taken:
             taken.add(alias)
             return [alias]
     return []
+
+
+def _flag_label(name: str) -> str:
+    return f"--{name.replace('_', '-')}"
+
+
+def _alias_key(alias: str) -> tuple[str, str]:
+    if alias.startswith("--"):
+        return ("long", alias.removeprefix("--").replace("-", "_"))
+    return ("short", alias)
+
+
+def _validate_option_alias(alias: str) -> None:
+    if alias.startswith("--"):
+        if len(alias) <= 2:
+            raise ValueError("Option alias '--' is invalid")
+        return
+    if alias.startswith("-"):
+        if len(alias) != 2:
+            raise ValueError(
+                f"Short option alias {alias!r} must be a single-character flag"
+            )
+        return
+    raise ValueError(f"Option alias {alias!r} must start with '-'")
+
+
+def _reserve_option_alias(
+    alias: str,
+    owner: str,
+    registry: dict[tuple[str, str], str],
+) -> None:
+    key = _alias_key(alias)
+    existing = registry.get(key)
+    if existing is not None:
+        raise ValueError(
+            f"Cannot use alias {alias!r} for option {owner!r}: "
+            f"conflicts with {existing}"
+        )
+    registry[key] = owner
 
 
 def extract_parameters(
@@ -482,8 +523,14 @@ def extract_parameters(
     options = {}
     # Track taken aliases (implicit options reserve theirs)
     taken_aliases: set[str] = set()
-    for opt in IMPLICIT_OPTIONS.values():
+    alias_registry: dict[tuple[str, str], str] = {}
+    for name, opt in IMPLICIT_OPTIONS.items():
+        _reserve_option_alias(
+            _flag_label(opt.name), f"implicit option {name!r}", alias_registry
+        )
         taken_aliases.update(opt.aliases)
+        for alias in opt.aliases:
+            _reserve_option_alias(alias, f"implicit option {name!r}", alias_registry)
 
     for name, parameter in signature.parameters.items():
         if parameter.kind == parameter.VAR_POSITIONAL:
@@ -562,7 +609,16 @@ def extract_parameters(
             if cli_name.replace("-", "_") in IMPLICIT_OPTIONS:
                 msg = f"Cannot use `{cli_name}` as an option name (overrides an implicit option automatically created by Xclif)"
                 raise ValueError(msg)
-            aliases = _auto_alias(cli_name, taken_aliases)
+            _reserve_option_alias(_flag_label(cli_name), name, alias_registry)
+            if opt_meta is not None and opt_meta.aliases is not None:
+                aliases = list(opt_meta.aliases)
+            else:
+                aliases = _auto_alias(cli_name, taken_aliases)
+            for alias in aliases:
+                _validate_option_alias(alias)
+                _reserve_option_alias(alias, name, alias_registry)
+                if not alias.startswith("--"):
+                    taken_aliases.add(alias)
             options[name] = _DefinitionOption(
                 cli_name,
                 converter,

--- a/src/xclif/parser.py
+++ b/src/xclif/parser.py
@@ -16,7 +16,7 @@ At each command level the scanner classifies every token::
 
     --name value    → long option (space form)
     --name=value    → long option (equals form)
-    -x              → short alias (looked up in the alias map)
+    -x, --alias     → alias (looked up in the alias map)
     --              → sentinel; everything after is a raw positional
     <subcommand>    → stops scanning; returns the index so the caller can recurse
     <anything else> → positional argument
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
 
 
 def _build_alias_map(options: dict[str, _DefinitionOption]) -> dict[str, str]:
-    """Build a mapping from short alias → param key."""
+    """Build a mapping from alias token → param key."""
     alias_map: dict[str, str] = {}
     for long_name, option in options.items():
         for alias in option.aliases:
@@ -92,6 +92,15 @@ def _build_flag_map(options: dict[str, _DefinitionOption]) -> dict[str, str]:
         cli_name = option.name.replace("-", "_")
         flag_map[cli_name] = param_key
     return flag_map
+
+
+def _resolve_long_option(
+    token: str,
+    flag_map: dict[str, str],
+    alias_map: dict[str, str],
+) -> str | None:
+    flag = token.removeprefix("--").replace("-", "_")
+    return flag_map.get(flag) or alias_map.get(token)
 
 
 def _type_name(converter: type) -> str:
@@ -118,6 +127,12 @@ def _convert_option_value(option: _DefinitionOption, raw: str) -> object:
 def _suggest_option(name: str, options: dict[str, _DefinitionOption]) -> str | None:
     """Suggest a close match for an unknown option name."""
     candidates = [f"--{opt.name.replace('_', '-')}" for opt in options.values()]
+    candidates.extend(
+        alias
+        for opt in options.values()
+        for alias in opt.aliases
+        if alias.startswith("--")
+    )
     matches = get_close_matches(name, candidates, n=1, cutoff=0.6)
     return matches[0] if matches else None
 
@@ -157,8 +172,7 @@ def _parse_token_stream(
             # Long option: --name value  or  --name=value
             if "=" in token:
                 name_part, value = token.split("=", 1)
-                flag = name_part.removeprefix("--").replace("-", "_")
-                name = flag_map.get(flag)
+                name = _resolve_long_option(name_part, flag_map, alias_map)
                 if name is None:
                     suggestion = _suggest_option(name_part, options)
                     hint = f"Did you mean '{suggestion}'?" if suggestion else None
@@ -168,8 +182,7 @@ def _parse_token_stream(
                     raise UsageError(f"Boolean flag {name_part!r} does not take a value")
                 parsed_opts[name].append(_convert_option_value(option, value))
             else:
-                flag = token.removeprefix("--").replace("-", "_")
-                name = flag_map.get(flag)
+                name = _resolve_long_option(token, flag_map, alias_map)
                 if name is None:
                     suggestion = _suggest_option(token, options)
                     hint = f"Did you mean '{suggestion}'?" if suggestion else None

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -330,6 +330,60 @@ def test_auto_alias_avoids_implicit_collision():
         assert alias != "-h"
 
 
+def test_explicit_option_aliases_skip_auto_alias():
+    def f(
+        dry_run: Annotated[bool, OptionMeta(aliases=["-n", "--dryrun"])] = False,
+    ) -> None: ...
+
+    args, opts = extract_parameters(f)
+
+    assert args == []
+    assert opts["dry_run"].aliases == ["-n", "--dryrun"]
+
+
+def test_explicit_empty_option_aliases_skip_auto_alias():
+    def f(name: Annotated[str, OptionMeta(aliases=[])] = "default") -> None: ...
+
+    args, opts = extract_parameters(f)
+
+    assert args == []
+    assert opts["name"].aliases == []
+
+
+def test_explicit_option_alias_conflicts_with_implicit_alias():
+    def f(name: Annotated[str, OptionMeta(aliases=["-h"])] = "") -> None: ...
+
+    with pytest.raises(ValueError, match="conflicts"):
+        extract_parameters(f)
+
+
+def test_explicit_option_alias_conflicts_with_auto_alias():
+    def f(
+        name: str = "",
+        dry_run: Annotated[bool, OptionMeta(aliases=["-n"])] = False,
+    ) -> None: ...
+
+    with pytest.raises(ValueError, match="conflicts"):
+        extract_parameters(f)
+
+
+def test_explicit_option_alias_conflicts_with_canonical_flag():
+    def f(
+        dry_run: bool = False,
+        force: Annotated[bool, OptionMeta(aliases=["--dry-run"])] = False,
+    ) -> None: ...
+
+    with pytest.raises(ValueError, match="conflicts"):
+        extract_parameters(f)
+
+
+def test_explicit_option_alias_requires_flag_syntax():
+    def f(name: Annotated[str, OptionMeta(aliases=["name"])] = "") -> None: ...
+
+    with pytest.raises(ValueError, match="must start with '-'"):
+        extract_parameters(f)
+
+
 # ---------------------------------------------------------------------------
 # extract_parameters — int/float/bool types now work
 # ---------------------------------------------------------------------------

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -155,6 +155,24 @@ def test_short_value_missing_raises():
         _parse_token_stream(opts, {}, ["-n"])
 
 
+def test_long_bool_alias():
+    opts = {"dry_run": _opt("dry_run", bool, aliases=["--dryrun"])}
+    _, parsed, _ = _parse_token_stream(opts, {}, ["--dryrun"])
+    assert parsed["dry_run"] == [True]
+
+
+def test_long_value_alias_space_form():
+    opts = {"name": _opt("name", str, aliases=["--username"])}
+    _, parsed, _ = _parse_token_stream(opts, {}, ["--username", "Alice"])
+    assert parsed["name"] == ["Alice"]
+
+
+def test_long_value_alias_equals_form():
+    opts = {"name": _opt("name", str, aliases=["--username"])}
+    _, parsed, _ = _parse_token_stream(opts, {}, ["--username=Alice"])
+    assert parsed["name"] == ["Alice"]
+
+
 # ---------------------------------------------------------------------------
 # _parse_token_stream — -- separator
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds explicit option aliases via `Option(aliases=[...])`, allowing callers to choose short or long aliases instead of relying on auto-generated single-character aliases.

## Details

- Adds `aliases` metadata to `Option` and carries it into `_DefinitionOption` during signature extraction.
- Validates alias syntax and catches collisions with implicit options, canonical flags, auto-generated aliases, and other explicit aliases.
- Teaches the parser to resolve long aliases in both space and equals forms.
- Updates option docs and architecture notes for short and long option aliases.

## Validation

- `uv run pytest tests/test_command.py tests/test_parser.py -q` -> 178 passed
- `env -u CODEX_CI -u CODEX_THREAD_ID -u CODEX_SANDBOX uv run pytest -q` -> 436 passed
